### PR TITLE
NP fix if body contains only sequences of \r\n & Removing mandatory headers To & Subject from signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/bin/

--- a/src/de/agitos/dkim/Canonicalization.java
+++ b/src/de/agitos/dkim/Canonicalization.java
@@ -54,6 +54,9 @@ public class Canonicalization {
 			// Remove trailing empty lines ...
 			while ("\r\n\r\n".equals(body.substring(body.length()-4, body.length()))) {
 				body = body.substring(0, body.length()-2);
+				if (body.length() < 4) {
+				    break;
+				}
 			}
 
 			return body;
@@ -91,6 +94,9 @@ public class Canonicalization {
 			// Remove trailing empty lines ...
 			while ("\r\n\r\n".equals(body.substring(body.length()-4, body.length()))) {
 				body = body.substring(0, body.length()-2);
+				if (body.length() < 4) {
+				    break;
+				}
 			}
 
 			return body;

--- a/src/de/agitos/dkim/DKIMSigner.java
+++ b/src/de/agitos/dkim/DKIMSigner.java
@@ -61,8 +61,6 @@ public class DKIMSigner {
 	private static ArrayList<String> minimumHeadersToSign = new ArrayList<String>();
 	static {
 		minimumHeadersToSign.add("From");
-		minimumHeadersToSign.add("To");
-		minimumHeadersToSign.add("Subject");
 	}
 	
 	private String[] defaultHeadersToSign = new String[]{


### PR DESCRIPTION
Issue scenarios & fixes
1. When the body of the mail contains even sequences of \r\n then during either of the simple or relaxed canonicalization techniques null pointer exception gets thrown which is fixed
2. To & Subject headers have been removed from mandatory tags as mails sent from mail client for instance need not have the headers but the mail is valid & need to be signed
